### PR TITLE
Make minor wording change

### DIFF
--- a/home/templates/home/about.html
+++ b/home/templates/home/about.html
@@ -49,7 +49,7 @@ External link: <a href="{{ item.link }}" target="_blank">{{ item.link }}</a>
 
 {% if item.job%}
 <p><b>
-<a href="{{ item.job.url }}">Open job or PhD position!</a>
+<a href="{{ item.job.url }}">Open position!</a>
 </b></p>
 {% endif %}
 

--- a/home/templates/home/research.html
+++ b/home/templates/home/research.html
@@ -30,7 +30,7 @@
 <br />
 {{item.institution}}
 {% if item.job %}
-<b><br/>Open job/PhD position now!
+<b><br/>Open position available!
 </b>
 {% endif %}
 </p>

--- a/home/templates/home/research_behav.html
+++ b/home/templates/home/research_behav.html
@@ -30,7 +30,7 @@
 <br />
 {{item.institution}}
 {% if item.job %}
-<b><br/>Open job/PhD position now!
+<b><br/>Open position available!
 </b>
 {% endif %}
 </p>

--- a/home/templates/home/research_neuro.html
+++ b/home/templates/home/research_neuro.html
@@ -30,7 +30,7 @@
 <br />
 {{item.institution}}
 {% if item.job %}
-<b><br/>Open job/PhD position now!
+<b><br/>Open position available!
 </b>
 {% endif %}
 </p>


### PR DESCRIPTION
Change "Open job/PhD position" to a more general "Open position"; change "Open job/PhD position now!" to "Open position available!" in templates for Research & Join Us pages.

This was suggested by one of our collaborators. Personally I have no opinion which wording is better. Feel free to accept, modify further or discard.