### PR TITLE
Fix html tags

### DIFF
--- a/home/templates/home/index.html
+++ b/home/templates/home/index.html
@@ -6,7 +6,7 @@
 <!--<h1 class="title">Home</h1>
 <br />-->
 <div class="entry">
-<p>Laboratory of Brain Imaging is a core facility at 
+<p>Laboratory of Brain Imaging is a core facility at
   <a href="http://en.nencki.edu.pl/">Nencki Institute</a>.
   LOBI provides access to cutting edge research support and technologies for internal and external customers. The core technologies being developed and used at the Laboratory are magnetic resonance imaging (MRI), spectroscopy (MRS), electroencephalograpy (EEG - including EEG-fMRI simultaneous recordings), Transcranial Magnetic Stimulation (TMS) and computational image analysis.<br>
 
@@ -17,7 +17,7 @@
 &#9658; <a href="{{SERVER_URL}}/join">Join Us</a><br>
 
 <h2>Latest news</h2>
-</br>
+<br>
 <table border="0" width="100%">
   <tbody>
 	{% for item in news %}
@@ -28,10 +28,10 @@
 		{% endif %}
 	  </td>
       <td>
-      <p>
 		<h3>
 		{{ item.title }}
 		</h3>
+    <p>
 		{{ item.content|safe }}
 
 		</p>

--- a/home/templates/home/index.html
+++ b/home/templates/home/index.html
@@ -1,6 +1,7 @@
 {% extends "home/base.html" %}
 {% load i18n %}
 {% load static %}
+{% load home_extras %}
 {% block main_content %}
 <div class="post">
 <!--<h1 class="title">Home</h1>
@@ -32,7 +33,7 @@
 		{{ item.title }}
 		</h3>
     <p>
-		{{ item.content|safe }}
+		{{ item.content|dropptag|safe}}
 
 		</p>
       </td>

--- a/home/templates/home/news.html
+++ b/home/templates/home/news.html
@@ -17,12 +17,11 @@
 		{% endif %}
 	  </td>
       <td>
-      <p>
 		<h3>
 		{{ item.title }}
 		</h3>
+    <p>
 		{{ item.content|safe }}
-
 		</p>
       </td>
     </tr>

--- a/home/templates/home/news.html
+++ b/home/templates/home/news.html
@@ -1,5 +1,6 @@
 {% extends "home/base.html" %}
 {% load i18n %}
+{% load home_extras %}
 
 {% block main_content %}
 <div class="post">
@@ -21,7 +22,7 @@
 		{{ item.title }}
 		</h3>
     <p>
-		{{ item.content|safe }}
+		{{ item.content|dropptag|safe }}
 		</p>
       </td>
     </tr>

--- a/home/templates/home/person.html
+++ b/home/templates/home/person.html
@@ -1,6 +1,7 @@
 {% extends "home/base.html" %}
 {% load i18n %}
 {% load static %}
+{% load home_extras %}
 
 {% block main_content %}
 <div class="post">
@@ -40,7 +41,7 @@
 {% if user.profile.about %}
 <h2>About me:</h2>
 <p>
-{{ user.profile.about|safe }}
+{{ user.profile.about|dropptag|safe }}
 </p>
 {% endif %}
 

--- a/home/templates/home/person.html
+++ b/home/templates/home/person.html
@@ -58,7 +58,7 @@
   {% if user.profile.github %}
   <div>
     <a href="https://github.com/{{ user.profile.github }}/">
-      <img src="{% static 'images/GitHub-Mark-32px.png' %}", height="16", width="16", style="width:1em;margin-right:.5em;", alt="GitHub mark">
+      <img src="{% static 'images/GitHub-Mark-32px.png' %}" height="16" width="16" style="width:1em;margin-right:.5em;" alt="GitHub mark">
       github.com/{{user.profile.github}}
     </a>
   </div>
@@ -67,7 +67,7 @@
   {% if user.profile.scholar %}
   <div>
     <a href="https://scholar.google.com/citations?user={{ user.profile.scholar }}">
-      <img src="{% static 'images/Google-Scholar-Icon.png' %}", height="16", width="16", style="width:1em;margin-right:.5em;", alt="Google Scholar icon">
+      <img src="{% static 'images/Google-Scholar-Icon.png' %}" height="16" width="16" style="width:1em;margin-right:.5em;" alt="Google Scholar icon">
       Google Scholar
     </a>
   </div>
@@ -76,7 +76,7 @@
   {% if user.profile.researchgate %}
   <div>
     <a href="https://www.researchgate.net/profile/{{ user.profile.researchgate }}">
-      <img src="{% static 'images/ResearchGate-Icon.png' %}", , height="16", width="16", style="width:1em;margin-right:.5em;", alt="ResearchGate icon">
+      <img src="{% static 'images/ResearchGate-Icon.png' %}" height="16" width="16" style="width:1em;margin-right:.5em;" alt="ResearchGate icon">
       ResearchGate
     </a>
   </div>

--- a/home/templates/home/team.html
+++ b/home/templates/home/team.html
@@ -22,8 +22,9 @@
 </a>
 	  </td>
       <td>
-      <p><b>
+      <p>
 <a href="{{ user.id }}/">
+<b>
 {{ user.first_name }} {{ user.last_name }}{% if user.profile.degree %}, {{user.profile.degree}}{% endif %}
 </b>
 {% if user.profile.position %}
@@ -63,8 +64,9 @@
 </a>
 	  </td>
       <td>
-      <p><b>
+      <p>
 <a href="{{ user.id }}/">
+<b>
 {{ user.first_name }} {{ user.last_name }}{% if user.profile.degree %}, {{user.profile.degree}}{% endif %}
 </b>
 {% if user.profile.position %}

--- a/home/templatetags/home_extras.py
+++ b/home/templatetags/home_extras.py
@@ -1,0 +1,15 @@
+from django import template
+from django.template.defaultfilters import stringfilter
+import re
+
+register = template.Library()
+
+@register.filter
+@stringfilter
+def dropptag(value):
+    """Removes opening / closing tags from beginning and end.
+    Use before safe."""
+
+    new_value = re.sub(r'^<p>', '', value)  # opening
+    new_value = re.sub(r'</p>\s*$', '', new_value)  # closing + trailing whtsp
+    return new_value


### PR DESCRIPTION
I tried to make the `<p>` tags around the news content on the index page actually work (by putting them after headers).

While doing this, I added a filter that removes `<p>` tag from the start, and `</p>` tag from the end of text, so that we avoid duplicating them (applied on index, news & team pages). I also cleaned some minor html annoyances which I found.

This will change the look of the title page (we have `line-height` specified for `p` in css) - but at least it will be the same for all news (and changes can be made in css).

More details in commit messages.